### PR TITLE
Allow shutdown without callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,10 @@ const getConnection = (dbName, callback) => {
 }
 
 const shutDown = callback => {
+    if (typeof callback !== 'function') {
+        callback = () => {}
+    }
+
     if (serverEmitter) {
         debug('emit shutdown event')
         serverEmitter.emit('mongoShutdown')


### PR DESCRIPTION
Sometimes I don't care about shutdown result, so I need to do this:

```
mockgo.shutDown(function() {
});
```
